### PR TITLE
Added CLI option to configure served host

### DIFF
--- a/bin/ethers-build
+++ b/bin/ethers-build
@@ -35,6 +35,7 @@ var options = {
 
     head: false,
     published: false,
+    host: '127.0.0.1',
     port: 8080,
     slug: [],
     signed: false,
@@ -355,7 +356,7 @@ function doPublish(slugData) {
     return api.putSlug(null, slugData);
 }
 
-function doServe(provider, port, slug, options) {
+function doServe(provider, host, port, slug, options) {
 
     if (slug) {
         var handler = function(path) {
@@ -376,7 +377,7 @@ function doServe(provider, port, slug, options) {
         var handler = WebServer.staticFileHandler();
     }
 
-    var webServer = new WebServer(handler, { port: port });
+    var webServer = new WebServer(handler, { host: host, port: port });
 
     webServer.addOverride(accountFilename, WebServer.makeError(403, 'Forbidden'));
 
@@ -598,7 +599,7 @@ getopts(options).then(function(opts) {
             if (slugs.length) {
                 slug = Slug.verify(fs.readFileSync(slugs[0]).toString(), true);
             }
-            return (function() { doServe(opts.provider, options.port, slug, options); });
+            return (function() { doServe(opts.provider, opts.options.host, opts.options.port, slug, options); });
         })();
 
         case 'status': return (function() {
@@ -713,7 +714,7 @@ getopts(options).then(function(opts) {
     console.log('    ethers-build deploy FILENAME.js [ Node + Account + Tx Options ]');
     console.log('    ethers-build deploy FILENAME.sol [ Node + Account + Tx Options ]');
     console.log('');
-    console.log('    ethers-build serve [ --slug SLUG ] [ --port PORT ] [ Node Options ]');
+    console.log('    ethers-build serve [ --slug SLUG ] [ --host HOST ] [ --port PORT ] [ Node Options ]');
     console.log('    ethers-build init');
     console.log('    ethers-build status [ --head ] [ --slug A ] [ --slug B ] [ --published ]');
     console.log('    ethers-build diff [ --head ] [ --slug A ] [ --slug B ] [ --published ]');

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -15,6 +15,7 @@ function WebServer(handler, options) {
 
     this.handler = handler;
     this.port = (options.port || 8000);
+    this.host = (options.host || '127.0.0.1');
 
     this._overrides = {};
 }
@@ -77,7 +78,7 @@ WebServer.prototype.start = function(callback) {
     }
 
     var server = http.createServer(listener);
-    server.listen(this.port, '127.0.0.1', function() {
+    server.listen(this.port, this.host, function() {
         if (callback) { callback(); }
     });
 }


### PR DESCRIPTION
This is especially usefull when using ethers-build through a docker
container, one might pass `--host 0.0.0.0` in order to correctly access
the web server from the container host.

The current hardcoded value `127.0.0.1` prevents this.

This PR will allow using `ethers-cli serve` in a container and access the web server from the host.

Here's an example:

```bash
$ docker run --rm -ti -v "$(pwd):/app" -w /app -p "8080:8080" gquemener/node-toolbox:latest ethers-build serve --host 0.0.0.0 --port 8080
Serving content from file:///app
Listening on port: 8080
Server Ethers app: http://localhost:8080/_/#!/app-link-insecure/localhost:8080/
```

You may now open the provided url in your favorite browser on your docker host.

As a bonus, this PR also fixes the `--port` option value which was ignored before.